### PR TITLE
CHORE: 6주차 스탠다드 로그기록 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,12 @@ Postman 에서 확인할 수 있는 날짜 범위 사이 글목록. found로 접
 </div>
 </details>
 
+***
+<details>
+<summary> week6 스탠다드 (서버 로그확인)</summary>
+<div makedown="5">
+
+![image](https://github.com/LikeLion-at-CAU-12th/YeBin-Park/assets/114918259/95f77093-d1c8-45a0-a3b3-506348e9749b)
+putty의 logging 기능을 이용해 배포한 서버가 받은 요청들을 로그로 확인하고, 파일로도 저장할 수 있었다.
+</div>
+</details>

--- a/week4/posts/views.py
+++ b/week4/posts/views.py
@@ -38,7 +38,7 @@ def post_list(request):
     if request.method== "GET":
         post_all= Post.objects.all()
 
-        #JSon 형식으로 변환하여 리스트로 저장
+        #JSon 형식으로 변환하여 리스트로 저장.
         post_json_all =[]
 
         for post in post_all:


### PR DESCRIPTION
배포한 서버의 로그기록 사진을 추가했습니다!

이번에 서버를 배포하면서, 기존에 있던(week5 까지 postman 으로 확인했던 ) post와 comments 는 사라져있어서 다시 생성했는데 
원래 사라지면 안되는건가요?? 아니면 원래 배포하면서 초기화 되는게 맞나요?
vsc 에서 sqlite 를 확인해보면 이전 주차의 post와 comment는 그대로 있습니다